### PR TITLE
Remove unnecessary async

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -40,7 +40,7 @@ lazy_static::lazy_static! {
     };
 }
 
-pub async fn get_x25519_symmetric_key(
+pub fn get_x25519_symmetric_key(
     public_key: &[u8], private_key: &x25519_dalek::StaticSecret,
 ) -> Result<Vec<u8>, warp::reject::Rejection> {
     if public_key.len() != 32 {
@@ -58,7 +58,7 @@ pub async fn get_x25519_symmetric_key(
     return Ok(mac.finalize().into_bytes().to_vec());
 }
 
-pub async fn encrypt_aes_gcm(
+pub fn encrypt_aes_gcm(
     plaintext: &[u8], symmetric_key: &[u8],
 ) -> Result<Vec<u8>, warp::reject::Rejection> {
     let mut iv = [0u8; IV_SIZE];
@@ -77,7 +77,7 @@ pub async fn encrypt_aes_gcm(
     };
 }
 
-pub async fn decrypt_aes_gcm(
+pub fn decrypt_aes_gcm(
     iv_and_ciphertext: &[u8], symmetric_key: &[u8],
 ) -> Result<Vec<u8>, warp::reject::Rejection> {
     if iv_and_ciphertext.len() < IV_SIZE {
@@ -96,7 +96,7 @@ pub async fn decrypt_aes_gcm(
     };
 }
 
-pub async fn generate_x25519_key_pair() -> (x25519_dalek::StaticSecret, x25519_dalek::PublicKey) {
+pub fn generate_x25519_key_pair() -> (x25519_dalek::StaticSecret, x25519_dalek::PublicKey) {
     let private_key = x25519_dalek::StaticSecret::new(OsRng);
     let public_key = x25519_dalek::PublicKey::from(&private_key);
     return (private_key, public_key);

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,6 @@ async fn create_default_rooms() {
     for info in info {
         let id = info.0;
         let name = info.1;
-        handlers::create_room(id, name).await.unwrap();
+        handlers::create_room(id, name).unwrap();
     }
 }

--- a/src/onion_requests.rs
+++ b/src/onion_requests.rs
@@ -97,9 +97,8 @@ async fn decrypt_onion_request_payload(
     payload: OnionRequestPayload,
 ) -> Result<(Vec<u8>, Vec<u8>), Rejection> {
     let ephemeral_key = hex::decode(payload.metadata.ephemeral_key).unwrap(); // Safe because it was validated in the parsing step
-    let symmetric_key =
-        crypto::get_x25519_symmetric_key(&ephemeral_key, &crypto::PRIVATE_KEY).await?;
-    let plaintext = crypto::decrypt_aes_gcm(&payload.ciphertext, &symmetric_key).await?;
+    let symmetric_key = crypto::get_x25519_symmetric_key(&ephemeral_key, &crypto::PRIVATE_KEY)?;
+    let plaintext = crypto::decrypt_aes_gcm(&payload.ciphertext, &symmetric_key)?;
     return Ok((plaintext, symmetric_key));
 }
 
@@ -112,7 +111,7 @@ async fn encrypt_response(response: Response, symmetric_key: &[u8]) -> Result<Re
         let error = models::StatusCode { status_code: response.status().as_u16() };
         bytes = serde_json::to_vec(&error).unwrap();
     }
-    let ciphertext = crypto::encrypt_aes_gcm(&bytes, symmetric_key).await.unwrap();
+    let ciphertext = crypto::encrypt_aes_gcm(&bytes, symmetric_key).unwrap();
     let json = base64::encode(&ciphertext);
     let response =
         warp::http::Response::builder().status(StatusCode::OK.as_u16()).body(json).into_response();

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -71,7 +71,7 @@ async fn handle_get_request(
     // Handle routes that don't require authorization first
     if path == "auth_token_challenge" {
         let pool = get_pool_for_room(&rpc_call)?;
-        let challenge = handlers::get_auth_token_challenge(query_params, &pool).await?;
+        let challenge = handlers::get_auth_token_challenge(query_params, &pool)?;
         #[derive(Debug, Deserialize, Serialize)]
         struct Response {
             status_code: u16,
@@ -83,13 +83,13 @@ async fn handle_get_request(
         reject_if_file_server_mode(path)?;
         let components: Vec<&str> = path.split("/").collect(); // Split on subsequent slashes
         if components.len() == 1 {
-            return handlers::get_all_rooms().await;
+            return handlers::get_all_rooms();
         } else if components.len() == 2 {
             let room_id = components[1];
-            return handlers::get_room(&room_id).await;
+            return handlers::get_room(&room_id);
         } else if components.len() == 3 && components[2] == "image" {
             let room_id = components[1];
-            return handlers::get_group_image(&room_id).await;
+            return handlers::get_group_image(&room_id);
         } else {
             println!("Invalid endpoint: {}.", rpc_call.endpoint);
             return Err(warp::reject::custom(Error::InvalidRpcCall));
@@ -113,32 +113,31 @@ async fn handle_get_request(
             }
         };
         return handlers::get_file(file_id, &auth_token, &pool)
-            .await
             .map(|json| warp::reply::json(&json).into_response());
     }
     match path {
         "messages" => {
             reject_if_file_server_mode(path)?;
-            return handlers::get_messages(query_params, &auth_token, &pool).await;
+            return handlers::get_messages(query_params, &auth_token, &pool);
         }
         "deleted_messages" => {
             reject_if_file_server_mode(path)?;
-            return handlers::get_deleted_messages(query_params, &auth_token, &pool).await;
+            return handlers::get_deleted_messages(query_params, &auth_token, &pool);
         }
         "moderators" => {
             reject_if_file_server_mode(path)?;
-            return handlers::get_moderators(&auth_token, &pool).await;
+            return handlers::get_moderators(&auth_token, &pool);
         }
         "block_list" => {
             reject_if_file_server_mode(path)?;
-            return handlers::get_banned_public_keys(&auth_token, &pool).await;
+            return handlers::get_banned_public_keys(&auth_token, &pool);
         }
         "member_count" => {
             reject_if_file_server_mode(path)?;
-            return handlers::get_member_count(&auth_token, &pool).await;
+            return handlers::get_member_count(&auth_token, &pool);
         }
         "auth_token_challenge" => {
-            let challenge = handlers::get_auth_token_challenge(query_params, &pool).await?;
+            let challenge = handlers::get_auth_token_challenge(query_params, &pool)?;
             #[derive(Debug, Deserialize, Serialize)]
             struct Response {
                 status_code: u16,
@@ -171,7 +170,7 @@ async fn handle_post_request(
                     return Err(warp::reject::custom(Error::InvalidRpcCall));
                 }
             };
-            return handlers::insert_message(message, &auth_token, pool).await;
+            return handlers::insert_message(message, &auth_token, pool);
         }
         "block_list" => {
             reject_if_file_server_mode(path)?;
@@ -186,7 +185,7 @@ async fn handle_post_request(
                     return Err(warp::reject::custom(Error::InvalidRpcCall));
                 }
             };
-            return handlers::ban(&json.public_key, &auth_token, pool).await;
+            return handlers::ban(&json.public_key, &auth_token, pool);
         }
         "claim_auth_token" => {
             #[derive(Debug, Deserialize)]
@@ -200,7 +199,7 @@ async fn handle_post_request(
                     return Err(warp::reject::custom(Error::InvalidRpcCall));
                 }
             };
-            return handlers::claim_auth_token(&json.public_key, &auth_token, pool).await;
+            return handlers::claim_auth_token(&json.public_key, &auth_token, pool);
         }
         "files" => {
             #[derive(Debug, Deserialize)]
@@ -214,7 +213,7 @@ async fn handle_post_request(
                     return Err(warp::reject::custom(Error::InvalidRpcCall));
                 }
             };
-            return handlers::store_file(&json.file, &auth_token, pool).await;
+            return handlers::store_file(&json.file, &auth_token, pool);
         }
         _ => {
             println!("Ignoring RPC call with invalid or unused endpoint: {}.", path);
@@ -243,7 +242,7 @@ async fn handle_delete_request(
                 return Err(warp::reject::custom(Error::InvalidRpcCall));
             }
         };
-        return handlers::delete_message(server_id, &auth_token, pool).await;
+        return handlers::delete_message(server_id, &auth_token, pool);
     }
     // DELETE /block_list/:public_key
     if path.starts_with("block_list") {
@@ -254,11 +253,11 @@ async fn handle_delete_request(
             return Err(warp::reject::custom(Error::InvalidRpcCall));
         }
         let public_key = components[1].to_string();
-        return handlers::unban(&public_key, &auth_token, pool).await;
+        return handlers::unban(&public_key, &auth_token, pool);
     }
     // DELETE /auth_token
     if path == "auth_token" {
-        return handlers::delete_auth_token(&auth_token, pool).await;
+        return handlers::delete_auth_token(&auth_token, pool);
     }
     // Unrecognized endpoint
     println!("Ignoring RPC call with invalid or unused endpoint: {}.", path);


### PR DESCRIPTION
Marking a function as `async` just allows you to call `await` inside the its body. It does not actually accomplish anything on its own (and even comes with a small overhead, but probably negligible). It is a bit deceiving too, because one might think that `store_file` is non-blocking when in fact it is (you might want to look into https://docs.rs/tokio/1.4.0/tokio/fs/struct.File.html to do it in a non-blocking way). For now, I think it is better to make them regular functions (i.e. non-async) until we add some non-blocking (with `.await`) functionality to them.