### PR TITLE
Update session-open-group-server.postinst

### DIFF
--- a/debian/session-open-group-server.postinst
+++ b/debian/session-open-group-server.postinst
@@ -2,6 +2,6 @@
 
 #DEBHELPER#
 
-mkdir /var/lib/session-open-group-server
+mkdir -p /var/lib/session-open-group-server
 openssl genpkey -algorithm x25519 -out /var/lib/session-open-group-server/x25519_private_key.pem
 openssl pkey -in /var/lib/session-open-group-server/x25519_private_key.pem -pubout -out /var/lib/session-open-group-server/x25519_public_key.pem


### PR DESCRIPTION
use `mkdir -p` in postint script so that `mkdir` doesn't error if `/var/lib/session-open-group-sever` already exists