### PR TITLE
Use atomics and rwlock for fields modified only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ dependencies = [
  "lazy_static",
  "log",
  "log4rs",
+ "parking_lot",
  "r2d2",
  "r2d2_sqlite",
  "rand 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { version = "1.3", features = ["full"] }
 url = "2.2.1"
 warp = { version = "0.3", features = ["tls"] }
 x25519-dalek = "1.1"
+parking_lot = "0.11.1"
 
 [dev-dependencies]
 tokio-test = "*"


### PR DESCRIPTION
Not performance critical code, but it is better to use more appropriate types as a habit
- uses lighter-weight atomics rather than a mutex for primitives
- uses `RwLock` for a String, which is more appropriate for a value that is only ever modified once
- brings in `parking_lot` as a dependency, which is generally better than the standard library for concurrency primitives. (its `RwLock` should be more performant than the one from std, and does not require unwrapping. I think there is more opportunities in the codebase to use `RwLock` for the data that's requested frequently, but does not get modified very often.)