### PR TITLE
Add docker support

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,82 @@
+# Deploying with Docker
+
+Deploying with Docker allows you to run Session Group Server on any operating system without having to deal with OS-specific quirks.  
+In some instances it might be more beginner-friendly, however it is also slightly more demanding in terms of resource usage.
+
+## Requirements
+
+- A server with [Docker](https://docker.com) installed
+- git
+
+## Setup
+
+### Step 1: Clone the repository
+
+```bash
+git clone https://github.com/nielsandriesse/session-open-group-server.git
+cd session-open-group-server
+```
+
+### Step 2: Create or pull a docker image
+
+```bash
+sudo docker build -t session-open-group-server .
+```
+
+This will create an image for our container called `session-open-group-server`.   
+If your device can't handle the building process or you don't want to build on your server machine, in the next step you will be told how to use a pre-built image.
+
+### Step 3: Run the docker image
+
+```bash
+sudo docker run \    
+    --name session-open-group \
+    --restart unless-stopped \
+    -v session-open-group-data:/session-open-group-server/target/release/data \
+    -p 9999:80 \
+    session-open-group-server
+```
+
+This will start an auto-restarting container named `session-open-group` on port 9999, with a persistent data volume called `session-open-group-data`, based on the image we've created in the step before.  
+*If you've chosen to use a pre-built image*, replace  `session-open-group-server` with `massiveboxe/session-open-group`.
+
+Tip: You can add the `-d` flag after `docker run` to start the container in the background.
+
+### Step 4: Configure
+
+This command will connect you to the container's internal command line:
+
+```bash
+sudo docker exec -it session-open-group /bin/sh
+```
+
+And this one will take you to the path where the server binary is stored:
+
+```bash
+cd /session-open-group-server/target/release
+```
+
+You can now edit the configuration as you please. You can follow the [steps indicated in the README.md](https://github.com/nielsandriesse/session-open-group-server#step-2-add-a-room) and [the CLI reference](https://github.com/nielsandriesse/session-open-group-server/blob/main/CLI.md), just **remember to use** `./session-open-group-server` **instead of** `session-open-group-server` **or** `/usr/bin/session-open-group-server`**.** Examples:
+
+- Print the server URL: `./session-open-group-server --print-url`
+- Become moderator of a room: `./session-open-group-server --add-moderator {your_session_id} {room_id}`
+
+*Once you're done configuring*, exit the internal command line with this command:
+
+```bash
+exit
+```
+
+You don't need to restart the container after changing the configuration.
+
+### Step 5: Enjoy
+
+Your Session Open Groups server is ready.  
+You can join it using the link sent on server startup or with the `--print-url` flag. However, **don't forget to add the port!** Since the server is running in a Docker container serving on port 9999, this is the correct URL:
+
+```
+http://[host_name_or_ip]:9999/[room_id]?public_key=[public_key]
+```
+
+(Replace 9999 with whatever port you chose in the `docker run` step if you didn't use 9999)
+

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -29,7 +29,7 @@ If your device can't handle the building process or you don't want to build on y
 ### Step 3: Run the docker image
 
 ```bash
-sudo docker run \    
+sudo docker run \
     --name session-open-group \
     --restart unless-stopped \
     -v session-open-group-data:/session-open-group-server/target/release/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:latest
+
+RUN apt-get update
+RUN apt-get upgrade -y
+
+RUN apt-get install curl -y
+RUN apt-get install build-essential -y
+RUN apt-get install libssl-dev -y
+RUN apt-get install pkg-config -y
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+
+RUN mkdir session-open-group-server
+ADD . /session-open-group-server
+WORKDIR session-open-group-server
+
+RUN ~/.cargo/bin/cargo build --release
+RUN mkdir ./target/release/data
+WORKDIR ./target/release/data
+
+RUN openssl genpkey -algorithm x25519 -out x25519_private_key.pem
+RUN openssl pkey -in x25519_private_key.pem -pubout -out x25519_public_key.pem
+
+CMD ["../session-open-group-server"]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 [CLI Reference](https://github.com/nielsandriesse/session-open-group-server/blob/main/CLI.md)
 
-Want to build from source? See [BUILDING.md](https://github.com/nielsandriesse/session-open-group-server/blob/main/BUILDING.md).
+Want to build from source? See [BUILDING.md](https://github.com/nielsandriesse/session-open-group-server/blob/main/BUILDING.md).  
+Want to deploy using Docker? See [DOCKER.md](https://github.com/nielsandriesse/session-open-group-server/blob/main/DOCKER.md).
 
 ## Installation Instructions
 
-**Note:** .debs for the Session Open Group server are currently only available for Ubuntu 20.04.
+**Note:** .debs for the Session Open Group server are currently only available for Ubuntu 20.04.  
+For other operating systems, you can either [build from source](https://github.com/nielsandriesse/session-open-group-server/blob/main/BUILDING.md) or use [Docker](https://github.com/nielsandriesse/session-open-group-server/blob/main/DOCKER.md).
 
 ### Step 1: Pull in the Session open group server executable:
 
@@ -72,7 +74,7 @@ For **example**:
 
 ```
 session-open-group-server --add-moderator 05d871fc80ca007eed9b2f4df72853e2a2d5465a92fcb1889fb5c84aa2833b3b40 fish
-``` 
+```
 
 
 ### Step 5: Add an image for your new room (Optional)


### PR DESCRIPTION
With this update users will be able to deploy the Session Open Group Server via docker.  
The documentation has been added or changed accordingly.  
The core functionality of the server has not been altered at all.

Feel free to ask for clarification or ask me to modify stuff.